### PR TITLE
Dbatiste/switch d2l focusable

### DIFF
--- a/d2l-textarea.html
+++ b/d2l-textarea.html
@@ -149,9 +149,7 @@ Custom property | Description | Default
 				maxlength$="[[maxlength]]"
 				minlength$="[[minlength]]"
 				name$="[[name]]"
-				on-blur="_handleBlur"
 				on-change="_handleChange"
-				on-focus="_handleFocus"
 				placeholder$="[[placeholder]]"
 				readonly$="[[readonly]]"
 				required$="[[required]]"
@@ -165,6 +163,10 @@ Custom property | Description | Default
 	Polymer({
 
 		is: 'd2l-textarea',
+
+		behaviors: [
+			D2L.PolymerBehaviors.FocusableBehavior
+		],
 
 		properties: {
 

--- a/d2l-textarea.html
+++ b/d2l-textarea.html
@@ -11,6 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-fastdom-import/fastdom.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-polymer-behaviors/d2l-focusable-behavior.html">
 <link rel="import" href="../d2l-text-input/d2l-text-input-shared-styles.html">
 
 <link rel="import" href="d2l-textarea-shared-styles.html">
@@ -142,6 +143,7 @@ Custom property | Description | Default
 				aria-labelledby$="[[ariaLabelledby]]"
 				autocomplete$="[[autocomplete]]"
 				autofocus$="[[autofocus]]"
+				class="d2l-focusable"
 				disabled$="[[disabled]]"
 				inputmode$="[[inputmode]]"
 				maxlength$="[[maxlength]]"
@@ -367,32 +369,6 @@ Custom property | Description | Default
 			fastdom.mutate(function() {
 				this.$.mirror.innerHTML = this._constrain(this.tokens);
 			}, this);
-		},
-
-		focus: function() {
-			this.textarea.focus();
-		},
-
-		_handleFocus: function() {
-			if (!Polymer.Element && !Polymer.Settings.useShadow) {
-				// This custom focus event is only needed for Polymer 1. We should
-				// be able to remove this event once we move to Polymer 2.
-				this.dispatchEvent(new CustomEvent(
-					'focus',
-					{bubbles: false}
-				));
-			}
-		},
-
-		_handleBlur: function() {
-			if (!Polymer.Element && !Polymer.Settings.useShadow) {
-				// This custom focus event is only needed for Polymer 1. We should
-				// be able to remove this event once we move to Polymer 2.
-				this.dispatchEvent(new CustomEvent(
-					'blur',
-					{bubbles: false}
-				));
-			}
 		},
 
 		_handleChange: function() {


### PR DESCRIPTION
Use shared d2l-focusable-behavior.

- removed unneeded focus method and focus/blur event handlers
- adds d2l-focusable-behavior
- adds d2l-focusable class (to identify the focusable element)
