### PR TITLE
add invalid styling when hover-styles/no-border being used

### DIFF
--- a/d2l-textarea.html
+++ b/d2l-textarea.html
@@ -118,7 +118,8 @@ Custom property | Description | Default
 			}
 
 			:host([hover-styles]) textarea:hover,
-			:host([hover-styles]) textarea:focus {
+			:host([hover-styles]) textarea:focus,
+			:host([hover-styles]) textarea[aria-invalid='true'] {
 				border-style: solid;
 				border-radius: 0;
 				border-color: var(--d2l-color-celestine);
@@ -128,6 +129,11 @@ Custom property | Description | Default
 				box-shadow: inset 0 2px 0 0 rgba(185, 194, 208, .2);
 				transition-property: none;
 			}
+
+			:host([hover-styles]) textarea[aria-invalid='true'] {
+				@apply --d2l-input-invalid;
+			}
+
 		</style>
 
 		<!-- the mirror sizes the input/textarea so it grows with typing -->
@@ -317,6 +323,10 @@ Custom property | Description | Default
 			// the same.
 			if (textarea.value !== value) {
 				textarea.value = !(value || value === 0) ? '' : value;
+			}
+
+			if (this.ariaInvalid === "true") {
+				this.ariaInvalid = false;
 			}
 
 			fastdom.mutate(function() {

--- a/d2l-textarea.html
+++ b/d2l-textarea.html
@@ -325,7 +325,7 @@ Custom property | Description | Default
 				textarea.value = !(value || value === 0) ? '' : value;
 			}
 
-			if (this.ariaInvalid === "true") {
+			if (this.ariaInvalid === 'true') {
 				this.ariaInvalid = false;
 			}
 


### PR DESCRIPTION
Supports showing a square red focus rectangle when the aria-invalid attribute/property is set and the no-border property is set. When a field is invalid we want to show the border even when the textarea is not focused/hovered.
Also add code to clear the aria-invalid property automatically when textarea contents change.